### PR TITLE
autocomplete item extension

### DIFF
--- a/examples/data-source.md
+++ b/examples/data-source.md
@@ -122,3 +122,39 @@ seajs.use(['autocomplete', 'jquery'], function(AutoComplete, $) {
     }).render();
 });
 ````
+
+## 单独指定最终表单值
+
+利用复杂结构，可以指定与选项文本不同的值作为最终表单值。
+
+在下面的示例中，数据项的 `value` 属性用来匹配，
+`label` 属性用于选项展示，`target` 作为最终用来提交的表单值。
+
+<input id="acTrigger6" type="text" value="" />
+
+````javascript
+seajs.use(['autocomplete', 'jquery'], function(AutoComplete, $) {
+    new AutoComplete({
+        trigger: '#acTrigger6',
+        filter: 'stringMatch',
+        dataSource: [
+            {
+                value: '天弘增利宝货币 000198 TIANHONGZENGLIBAO',
+                label: '天弘增利宝货币 000198',
+                target: '000198'
+            },
+            {
+                value: '交银21天 519716 JYLC21TZQA',
+                label: '交银21天 519716',
+                target: '519716'
+            },
+            {
+                value: '招商理财7天B 217026 ZSLC7TZQB',
+                label: '招商理财7天B 217026',
+                target: '217026'
+            }
+        ],
+        width: 200
+    }).render();
+});
+````

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -246,7 +246,7 @@ var AutoComplete = Overlay.extend({
     var data = this.get('data')[index];
 
     if (index >= 0 && item && data) {
-      this.input.setValue(data.label);
+      this.input.setValue(data.target);
       this.set('selectedIndex', index, {
         silent: true
       });
@@ -386,6 +386,7 @@ function locateResult(locator, data) {
 //   {
 //     label: '', 显示的字段
 //     value: '', 匹配的字段
+//     target: '', input的最终值
 //     alias: []  其他匹配的字段
 //   }
 
@@ -396,12 +397,14 @@ function normalize(data) {
       result.push({
         label: item,
         value: item,
+        target: item,
         alias: []
       });
     } else if (isObject(item)) {
       if (!item.value && !item.label) return;
       item.value || (item.value = item.label);
       item.label || (item.label = item.value);
+      item.target || (item.target = item.label);
       item.alias || (item.alias = []);
       result.push(item);
     }

--- a/tests/autocomplete-spec.js
+++ b/tests/autocomplete-spec.js
@@ -37,6 +37,7 @@ describe('Autocomplete', function () {
     expect(ac.get('data')).to.eql([{
       label: 'abc',
       value: 'abc',
+      target: 'abc',
       alias: [],
       highlightIndex: [
         [0, 1]
@@ -45,6 +46,7 @@ describe('Autocomplete', function () {
     {
       label: 'abd',
       value: 'abd',
+      target: 'abd',
       alias: [],
       highlightIndex: [
         [0, 1]
@@ -93,6 +95,7 @@ describe('Autocomplete', function () {
       expect(ac.get('data')).to.eql([{
         label: 'abc',
         value: 'abc',
+        target: 'abc',
         alias: [],
         highlightIndex: [
           [0, 1]
@@ -101,6 +104,7 @@ describe('Autocomplete', function () {
       {
         label: 'abd',
         value: 'abd',
+        target: 'abd',
         alias: [],
         highlightIndex: [
           [0, 1]
@@ -123,6 +127,7 @@ describe('Autocomplete', function () {
       expect(ac.get('data')).to.eql([{
         label: 'abc',
         value: 'abc',
+        target: 'abc',
         alias: [],
         highlightIndex: [
           [0, 1]
@@ -131,6 +136,7 @@ describe('Autocomplete', function () {
       {
         label: 'abd',
         value: 'abd',
+        target: 'abd',
         alias: [],
         highlightIndex: [
           [0, 1]
@@ -154,6 +160,7 @@ describe('Autocomplete', function () {
       expect(ac.get('data')).to.eql([{
         label: 'abc',
         value: 'abc',
+        target: 'abc',
         alias: [],
         highlightIndex: [
           [0, 1]
@@ -162,6 +169,7 @@ describe('Autocomplete', function () {
       {
         label: 'abd',
         value: 'abd',
+        target: 'abd',
         alias: [],
         highlightIndex: [
           [0, 1]
@@ -282,7 +290,7 @@ describe('Autocomplete', function () {
 
       expect(ac.get('filter')).to.eql(Filter['default']);
     });
-    it('should be called with 3 param', function () {
+    it('should be called with 4 param', function () {
       var spy = sinon.spy();
       Filter.filter = spy;
       ac = new AutoComplete({
@@ -295,6 +303,7 @@ describe('Autocomplete', function () {
       var data = [{
         label: 'abc',
         value: 'abc',
+        target: 'abc',
         alias: []
       }];
       expect(spy.withArgs(data, 'a').called).to.be.ok();
@@ -323,6 +332,25 @@ describe('Autocomplete', function () {
     expect(input.val()).to.be('abd');
     expect(ac.input.getValue()).to.be('abd');
     expect(spy.calledTwice).to.be.ok();
+  });
+
+  it('specify final input-value individually', function () {
+    var input = $('#test'),
+    ac = new AutoComplete({
+      trigger: '#test',
+      filter: 'stringMatch',
+      dataSource: ['abc', 'abd', 'cbd', {
+          value: '天弘增利宝货币 000198 TIANHONGZENGLIBAO',
+          label: '天弘增利宝货币 000198',
+          target: '000198'
+      }]
+    }).render();
+
+    ac.setInputValue('TIAN');
+    ac.set('selectedIndex', 0);
+    ac.selectItem();
+    expect(input.val()).to.be('000198');
+    expect(ac.input.getValue()).to.be('000198');
   });
 
   it('highlight item', function () {
@@ -495,32 +523,38 @@ describe('Autocomplete', function () {
     expect(ac.get('data')).to.eql([{
       label: 'aa',
       value: 'aa',
+      target: 'aa',
       alias: []
     },
     {
       label: 'ba',
       value: 'ba',
+      target: 'ba',
       alias: []
     },
     {
       label: 'ac',
       value: 'ac',
+      target: 'ac',
       alias: []
     },
     {
       label: 'bc',
       value: 'bc',
+      target: 'bc',
       alias: [],
       other: 'bc'
     },
     {
       label: 'ad',
       value: 'ad',
+      target: 'ad',
       alias: []
     },
     {
       label: 'ae',
       value: 'ae',
+      target: 'ae',
       alias: ['be']
     }]);
   });


### PR DESCRIPTION
- add `target` attribute, as final input-value after selection
- add new test case for the feature
- update existing test cases to run ok
- add example for the feature

新搞一个分支, 添加了测试用例和demo, 测试用例全部通过, demo可以按预期交互, 重新PR给你们.

你们的开发环境和开发方式跟我的比起来简直高大上啊, 平时还没这样玩过, 算是跟你们学习一把, 我还太菜了.

另外: 那个你不想合并的filter(`iStringMatch`), 我又精简了代码, 提交到另一个分支上了, 感兴趣可以审核一下: https://github.com/wonderbeyond/autocomplete/commit/ec09d4bafd7458e42d2c40f6ddad78c1106b843e

谢谢!
